### PR TITLE
Inconsistent DateTime Handling

### DIFF
--- a/TurboNotes.Core/Models/Note.cs
+++ b/TurboNotes.Core/Models/Note.cs
@@ -1,11 +1,13 @@
-﻿namespace TurboNotes.Core.Models;
+﻿using TurboNotes.Core.Services;
+
+namespace TurboNotes.Core.Models;
 
 public class Note
 {
     public int Id { get; set; }
     public string Title { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
-    public DateTime CreatedAt { get; set; } = DateTime.Now;
+    public DateTime CreatedAt { get; set; } = TimeService.GetCurrentUtcTime();
     public DateTime? Deadline { get; set; }
     public int CategoryId { get; set; }
     public Category? Category { get; set; }

--- a/TurboNotes.Core/Services/TimeService.cs
+++ b/TurboNotes.Core/Services/TimeService.cs
@@ -1,0 +1,29 @@
+﻿using TurboNotes.Core.Interfaces;
+
+namespace TurboNotes.Core.Services;
+
+public static class TimeService
+{
+    public static DateTime GetCurrentUtcTime() => DateTime.UtcNow;
+    
+    public static DateTime? ToUtc(DateTime? localTime)
+    {
+        if (!localTime.HasValue)
+        {
+            return null;
+        }
+
+        return DateTime.SpecifyKind(localTime.Value, DateTimeKind.Local).ToUniversalTime();
+    }
+    
+    public static DateTime? ToLocal(DateTime? utcTime)
+    {
+        if (!utcTime.HasValue)
+        {
+            return null;
+        }
+        
+        var properUtcTime = DateTime.SpecifyKind(utcTime.Value, DateTimeKind.Utc);
+        return properUtcTime.ToLocalTime();
+    }
+}

--- a/TurboNotes.Infrastructure/Data/SeedData.cs
+++ b/TurboNotes.Infrastructure/Data/SeedData.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using TurboNotes.Core.Models;
+using TurboNotes.Core.Services;
 
 namespace TurboNotes.Infrastructure.Data;
 
@@ -30,12 +31,14 @@ public static class SeedData
 
             for (var i = 1; i <= 13; i++)
             {
+                var localDeadline = yesterday.AddDays(random.Next(0, 10)).AddHours(random.Next(0, 24));
+                
                 var note = new Note
                 {
                     Title = $"Test note {i}",
                     Content = $"Test note content {i}",
-                    CreatedAt = DateTime.Now,
-                    Deadline = yesterday.AddDays(random.Next(0, 10)).AddHours(random.Next(0, 24)),
+                    CreatedAt = TimeService.GetCurrentUtcTime(),
+                    Deadline = TimeService.ToUtc(localDeadline),
                     CategoryId = random.Next(1, 5)
                 };
 

--- a/TurboNotes.Web/Controllers/HomeController.cs
+++ b/TurboNotes.Web/Controllers/HomeController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using TurboNotes.Core.Interfaces;
+using TurboNotes.Core.Services;
 using TurboNotes.Web.Models;
 using TurboNotes.Web.Models.ViewModels;
 
@@ -20,18 +21,8 @@ public class HomeController(INoteRepository noteRepository, ICategoryRepository 
         
         foreach (var note in notes)
         {
-            if (note.Deadline.HasValue)
-            {
-                note.Deadline = note.Deadline.Value.ToLocalTime();
-            }
-        }
-        
-        foreach (var note in notes)
-        {
-            if (note.Deadline.HasValue)
-            {
-                note.Deadline = note.Deadline.Value.ToLocalTime();
-            }
+            note.Deadline = TimeService.ToLocal(note.Deadline);
+            note.CreatedAt = TimeService.ToLocal(note.CreatedAt).GetValueOrDefault();
         }
 
         var viewModel = new NoteViewModel

--- a/TurboNotes.Web/Controllers/NotesController.cs
+++ b/TurboNotes.Web/Controllers/NotesController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc.Rendering;
 using TurboNotes.Core.Interfaces;
 using TurboNotes.Core.Models;
+using TurboNotes.Core.Services;
 using TurboNotes.Web.Models.ViewModels;
 
 namespace TurboNotes.Web.Controllers;
@@ -30,11 +31,9 @@ public class NotesController(INoteRepository noteRepository, ICategoryRepository
         {
             Title = model.Note.Title,
             Content = model.Note.Content,
-            Deadline = model.Note.Deadline.HasValue
-                ? DateTime.SpecifyKind(model.Note.Deadline.Value, DateTimeKind.Local).ToUniversalTime()
-                : null,
+            Deadline = TimeService.ToUtc(model.Note.Deadline),
             CategoryId = model.Note.CategoryId,
-            CreatedAt = DateTime.UtcNow
+            CreatedAt = TimeService.GetCurrentUtcTime()
         };
         await noteRepository.CreateAsync(note);
         return RedirectToAction(nameof(Index), "Home");
@@ -46,7 +45,7 @@ public class NotesController(INoteRepository noteRepository, ICategoryRepository
         var note = await noteRepository.GetByIdAsync(id);
         if (note.Deadline.HasValue)
         {
-            note.Deadline = note.Deadline.Value.ToLocalTime();
+            note.Deadline = TimeService.ToLocal(note.Deadline);
         }
         
         var model = new NoteViewModel { Note = note };
@@ -74,9 +73,7 @@ public class NotesController(INoteRepository noteRepository, ICategoryRepository
 
         note.Title = model.Note.Title;
         note.Content = model.Note.Content;
-        note.Deadline = model.Note.Deadline.HasValue
-            ? DateTime.SpecifyKind(model.Note.Deadline.Value, DateTimeKind.Local).ToUniversalTime()
-            : null;
+        note.Deadline = TimeService.ToUtc(model.Note.Deadline);
         note.CategoryId = model.Note.CategoryId;
 
         await noteRepository.UpdateAsync(note);


### PR DESCRIPTION
# Code Smell: Inconsistent DateTime Handling Throughout the Application

## Description

Our application currently has inconsistent handling of date and time values across different components. This leads to potential bugs and maintenance challenges:

1. In `HomeController` we convert `Deadline` from UTC to local time for display
2. In `NotesController` we convert `Deadline` from local to UTC time before saving
3. `CreatedAt` field is handled inconsistently: using `DateTime.Now` in the model but `DateTime.UtcNow` in the `Create` method
4. `SeedData` doesn't perform any time zone conversions when creating records
5. `DeadlineNotificationService` directly uses `DateTime.UtcNow` for calculations

This inconsistent approach violates the DRY (Don't Repeat Yourself) principle and creates a code smell that makes the application harder to maintain and more error-prone, especially when dealing with different time zones.

## Expected Behavior

All date/time operations should follow a consistent pattern:
- Always store dates in UTC format in the database
- Convert to local time only when displaying to users
- Use a centralized service for all time-related operations

## Acceptance Criteria

- Create a centralized `TimeService` for consistent date/time handling
- Refactor all controllers to use this service
- Update model initialization to use the service
- Update `SeedData` initialization to use the service
- Update `DeadlineNotificationService` to use the service
- Ensure all dates displayed to users are in local time
- Ensure all dates stored in the database are in UTC time